### PR TITLE
Added API to get the number of clients connected to Node

### DIFF
--- a/server/ghosthttp/server.go
+++ b/server/ghosthttp/server.go
@@ -34,7 +34,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/ghostdb/ghostdb-cache-node/store/base"
@@ -72,8 +71,7 @@ func Router() {
 		path := ctx.Path()
 		cmd := string(path[1:])
 		body := ctx.PostBody()
-		clientIP := strings.Split(string(ctx.Host()),":")[0]
-		// if the map doesn't contain the ip create a key or else increment the counter for the key
+		clientIP := ctx.RemoteIP().String()
 		mu.Lock()
 		_ , isIPPresent := clientMap[clientIP]
 		if !isIPPresent {

--- a/server/ghosthttp/server.go
+++ b/server/ghosthttp/server.go
@@ -34,6 +34,8 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
+	"sync"
 
 	"github.com/ghostdb/ghostdb-cache-node/store/base"
 	"github.com/ghostdb/ghostdb-cache-node/store/request"
@@ -52,6 +54,7 @@ var (
 	GhostAppMetrics = "/getAppMetrics"
 	GhostPing       = "/ping"
 	GhostNodeSize   = "/nodeSize"
+	GhostClientConnections = "/getActiveConnections"
 )
 
 var store *base.Store
@@ -60,15 +63,25 @@ var store *base.Store
 func NodeConfig(s *base.Store) {
 	store = s
 }
-
 // Router passes control to handlers
 func Router() {
+	clientMap := make(map[string]int64)
+	var mu sync.RWMutex
 	routes := func(ctx *fasthttp.RequestCtx) {
 		req := new(request.CacheRequest)
 		path := ctx.Path()
 		cmd := string(path[1:])
 		body := ctx.PostBody()
-
+		clientIP := strings.Split(string(ctx.Host()),":")[0]
+		// if the map doesn't contain the ip create a key or else increment the counter for the key
+		mu.Lock()
+		_ , isIPPresent := clientMap[clientIP]
+		if !isIPPresent {
+			clientMap[clientIP] = 1
+		} else {
+			clientMap[clientIP]++
+		}
+		mu.Unlock()
 		if err := json.Unmarshal(body, &req); err != nil {
 			log.Println(err)
 			ctx.Request.Header.Set("Content-Type", "application/json; charset=UTF-8")
@@ -84,7 +97,9 @@ func Router() {
 			res = systemmonitor.GetSysMetrics()
 		} else if cmd == "ping" {
 			res = response.NewPingResponse()
-		} else {
+		} else if cmd == "getActiveConnections" {
+			res = response.NewCountConnectionsResponse(len(clientMap))
+		}else {
 			res = store.Execute(cmd, *req)
 		}
 
@@ -94,6 +109,12 @@ func Router() {
 		if err := json.NewEncoder(ctx).Encode(res); err != nil {
 			panic(err)
 		}
+		mu.Lock()
+		clientMap[clientIP]--
+		if clientMap[clientIP] == 0 {
+			delete(clientMap,clientIP)
+		}
+		mu.Unlock()
 	}
 	err := fasthttp.ListenAndServe(":7991", routes)
 	if err != nil {

--- a/store/response/response.go
+++ b/store/response/response.go
@@ -97,3 +97,12 @@ func NewPingResponse() CacheResponse {
 		Error:   "",
 	}
 }
+
+func NewCountConnectionsResponse(clientsConnected int) CacheResponse {
+	return CacheResponse{
+		Gobj:	object.NewCacheObjectFromValue(clientsConnected),
+		Status: 1,
+		Message: "Active Connections",
+		Error: "",
+	}
+}


### PR DESCRIPTION
#24
Added `\getActiveConnections` to get the number of active client connections to a node. 
Created a map with client's IP address as key and value as active number of requests. When the number of requests corresponding to the client equals 0 , the key is removed.
The length of the map corresponds to the number of active client connections.