### PR TITLE
Add .gitignore for exclusion of files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Intellij
+*.iml
+.idea


### PR DESCRIPTION
`.gitignore` to ignore files related to Golang builds and Intellij editor.