### PR TITLE
Add handler to get leader node

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -59,6 +59,8 @@ func (service *Service) Start() {
 			res = response.NewPingResponse()
 		} else if cmd == "join" {
 			handleJoin(ctx, service.store)
+		} else if cmd == "getLeader" {
+			res = handleGetLeader(ctx, service.store)
 		} else {
 			fmt.Println(service.store.RaftDir)
 			res = service.store.Execute(cmd, *req)
@@ -80,6 +82,10 @@ func (service *Service) Start() {
 type JoinRequest struct {
 	Addr   string `json:"addr"`
 	Id interface{} `json:"id"`
+}
+
+func handleGetLeader(ctx *fasthttp.RequestCtx, store *base.Store) response.CacheResponse {
+	return response.NewResponseFromMessage(string(store.Raft.Leader()), http.StatusOK)
 }
 
 func handleJoin(ctx *fasthttp.RequestCtx, store *base.Store) {


### PR DESCRIPTION
As this system is a leader-follower system, we need some way of determining which node in the cluster is the leader. This PR addresses this by adding a handler on the server to return the leader node IP address.